### PR TITLE
types: add missing RawContext field in fwpmFilter0

### DIFF
--- a/types.go
+++ b/types.go
@@ -164,6 +164,9 @@ type fwpmAction0 struct {
 	GUID CalloutID
 }
 
+// fwpmFilter0 is the Go representation of FWPM_FILTER0,
+// which stores the state associated with a filter.
+// See https://docs.microsoft.com/en-us/windows/win32/api/fwpmtypes/ns-fwpmtypes-fwpm_filter0
 //go:notinheap
 type fwpmFilter0 struct {
 	FilterKey           RuleID
@@ -177,10 +180,14 @@ type fwpmFilter0 struct {
 	NumFilterConditions uint32
 	FilterConditions    *fwpmFilterCondition0
 	Action              fwpmAction0
-	ProviderContextKey  windows.GUID
-	Reserved            *windows.GUID
-	FilterID            uint64
-	EffectiveWeight     fwpValue0
+
+	// Only one of RawContext/ProviderContextKey must be set.
+	RawContext         uint64
+	ProviderContextKey windows.GUID
+
+	Reserved        *windows.GUID
+	FilterID        uint64
+	EffectiveWeight fwpValue0
 }
 
 //go:notinheap


### PR DESCRIPTION
Addresses the first issue in https://github.com/tailscale/tailscale/issues/3260#issuecomment-962858025

I have tested this on Windows 7 32bit and it works fine. I still have to test it on a 64 bit machine and other windows versions.

Signed-off-by: Maisem Ali <maisem@tailscale.com>