### PR TITLE
.github/workflows: run on windows-2019 instead of windows-latest

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   test:
-    runs-on: windows-latest
+    runs-on: windows-2019
     steps:
     - name: Install Go
       uses: actions/setup-go@v2


### PR DESCRIPTION
The tests used to pass but then started failing because the CI environment
changed underfoot. Don't test on "latest". Pin to 2019 explicitly for now
until we adjust the tests to be tolerant of 2019 vs 2022, and then
we can add CI coverage for both.
